### PR TITLE
FAI-3227 Fix TypeError: Cannot set property message of  which has only a getter

### DIFF
--- a/src/components/GraphViewport.tsx
+++ b/src/components/GraphViewport.tsx
@@ -107,9 +107,10 @@ export default class GraphViewport extends React.Component<GraphViewportProps> {
       .catch((error) => {
         this._currentTypeGraph = null;
         this._currentDisplayOptions = null;
-
-        error.message = error.message || 'Unknown error';
         this.setState(() => {
+          if (typeof error === 'object') {
+            throw { ...error, message: error.message || 'Unknown error' };
+          }
           throw error;
         });
       });


### PR DESCRIPTION
Closes https://faros-ai.atlassian.net/browse/FAI-3227

Add fix to prevent error `TypeError: Cannot set property message of  which has only a getter`